### PR TITLE
I've implemented a two-stage Ollama pipeline for answer extraction. H…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,29 @@
-# AI-Powered Answer Sheet Grader
+# AI-Powered Answer Sheet Processing
 
 ## Overview
 
-This project is an AI-powered command-line application designed to automate the grading of student answer sheets. It leverages the capabilities of Google's Gemini language model to compare student-provided answers against a predefined answer key and generate a score along with qualitative feedback.
+This project provides command-line tools for AI-powered processing of student answer sheets. It currently offers two main functionalities:
 
-The system supports processing student answer sheets provided as PDF or common image files (PNG, JPG/JPEG). The answer key can be supplied as a PDF, an image file, or a plain TXT file.
+1.  **Ollama-based Answer Extraction:** This feature uses a local or remote Ollama instance in a two-stage process:
+    *   First, it takes a "question paper with answers (key)" file (PDF, image, or TXT), performs OCR, and uses an LLM to convert this text into a structured JSON representation of the question paper.
+    *   Second, using this generated JSON question paper, it extracts structured answers and metadata from the student's answer script (PDF, image, or TXT).
+    *   The final output is a JSON object mapping extracted answers to question numbers and including metadata.
+2.  **Gemini-based Automated Grading:** This original feature leverages Google's Gemini language model to compare student-provided answers against a predefined answer key and generate a score along with qualitative feedback.
+
+The system supports processing student answer sheets provided as PDF or common image files (PNG, JPG/JPEG). The answer key for the Gemini-based grading can be supplied as a PDF, an image file, or a plain TXT file.
 
 ## Features
 
 *   **Text Extraction:** Extracts text from PDF documents and various image formats (PNG, JPG, JPEG) using Optical Character Recognition (OCR).
-*   **AI-Driven Evaluation:** Utilizes the Gemini Pro model for intelligent comparison of student answers with the answer key, providing a percentage score and textual feedback.
-*   **Flexible Input:** Supports multiple file formats for both student sheets and answer keys.
+*   **Ollama-based Answer Extraction:**
+    *   **Two-Stage LLM Process:**
+        1.  Processes a "question paper with answers (key)" file (PDF, image, TXT) by performing OCR and then using an Ollama model to convert the OCR text into a structured JSON representation of the question paper (including questions, answers, marks, etc.).
+        2.  Uses this LLM-generated JSON question paper to guide a second Ollama model call that extracts answers and metadata from the student's answer script.
+    *   Outputs a structured JSON object mapping extracted answers to question numbers and including metadata.
+*   **AI-Driven Evaluation (Gemini):** Utilizes the Gemini Pro model for intelligent comparison of student answers with the answer key, providing a percentage score and textual feedback.
+*   **Flexible Input:** Supports multiple file formats for student sheets, question papers, and answer keys.
 *   **Command-Line Interface:** Easy to use via a command-line interface for processing and receiving results.
-*   **Modular Design:** Code is structured into modules for PDF processing, image processing, and AI scoring.
+*   **Modular Design:** Code is structured into modules for PDF processing, image processing, AI interaction (Ollama and Gemini), and answer extraction.
 *   **Test Suite:** Includes unit tests for verifying the functionality of different components.
 
 ## Setup and Installation
@@ -20,6 +31,7 @@ The system supports processing student answer sheets provided as PDF or common i
 ### Prerequisites
 
 1.  **Python:** Python 3.7 or newer is required. You can download it from [python.org](https://www.python.org/downloads/).
+2.  **Ollama (for answer extraction feature):** If using the answer extraction feature, you need a running Ollama instance accessible at the URL you provide. Refer to [Ollama.ai](https://ollama.ai/) for installation instructions.
 2.  **Tesseract-OCR:** This is essential for extracting text from image files.
     *   Installation instructions can be found on the official Tesseract documentation: [https://tesseract-ocr.github.io/tessdoc/Installation.html](https://tesseract-ocr.github.io/tessdoc/Installation.html). Please follow the instructions specific to your operating system.
     *   After installation, ensure that the Tesseract executable (`tesseract` or `tesseract.exe`) is in your system's PATH. For some systems or Python environments, you might need to configure the path to the Tesseract executable within your Python script or environment if `pytesseract` cannot find it automatically. Refer to the `pytesseract` documentation for more details if you encounter issues. The `requirements.txt` file includes a comment with an example of how to set this path in Python if needed.
@@ -29,7 +41,7 @@ The system supports processing student answer sheets provided as PDF or common i
 1.  **Clone the repository (if you haven't already):**
     ```bash
     git clone <repository_url>
-    cd <repository_name> 
+    cd <repository_name>
     ```
     (Replace `<repository_url>` and `<repository_name>` with the actual URL and project directory name)
 
@@ -53,16 +65,73 @@ The system supports processing student answer sheets provided as PDF or common i
     pip install -r requirements.txt
     ```
 
-### Gemini API Key
+### API Keys and Endpoints
 
-1.  **Obtain an API Key:** This project requires a Gemini API key to interact with the language model. You can obtain one from Google AI Studio:
-    *   Go to [https://aistudio.google.com/app/apikey](https://aistudio.google.com/app/apikey)
-    *   Sign in with your Google account and create an API key.
-2.  **Usage:** The API key is passed to the script as a command-line argument when you run the agent. **Do not hardcode your API key directly into the script.**
+*   **Ollama API Endpoint:** For the answer extraction feature, you'll need the base URL of your running Ollama instance (e.g., `http://localhost:11434`). This is passed via the `--ollama-url` argument.
+*   **Gemini API Key (for grading feature):**
+    1.  **Obtain an API Key:** The Gemini-based grading feature requires a Gemini API key. You can obtain one from Google AI Studio:
+        *   Go to [https://aistudio.google.com/app/apikey](https://aistudio.google.com/app/apikey)
+        *   Sign in with your Google account and create an API key.
+    2.  **Usage:** The API key is passed to the script as a command-line argument when you run the grading agent. **Do not hardcode your API key directly into the script.**
 
 ## How to Run
 
-The script is run from the command line, providing paths to the student's answer sheet, the answer key, and your Gemini API key.
+The `src/agent.py` script serves as the entry point for both functionalities, determined by the provided arguments.
+
+### Running the Ollama Answer Extractor
+
+This mode uses a two-stage LLM process. First, it generates a structured JSON representation of the question paper from an input "question paper with answers (key)" file. Second, it uses this generated JSON to extract answers from the student's script.
+
+**Command Syntax:**
+
+```bash
+python src/agent.py <student_sheet_path> <question_paper_path> --ollama-url <ollama_api_base_url> [--ollama-model <model_name>]
+```
+
+**Arguments:**
+
+*   `student_sheet_path`: Path to the student's answer sheet (PDF, PNG, JPG, JPEG, or TXT for OCR).
+*   `question_paper_path`: Path to the "question paper with answers (key)" file. This file can be a PDF, image (PNG, JPG, JPEG), or TXT file. It will be OCR'd, and its text content will be used by an LLM to generate a structured JSON representation of the question paper (including questions, answers, marks, etc.). This generated JSON is then used in the subsequent answer extraction step.
+*   `--ollama-url`: (Required) Base URL for the Ollama API (e.g., `http://localhost:11434`).
+*   `--ollama-model`: (Optional) Name of the Ollama model to use for both stages (default: `gemma3:12b`).
+
+**Example Command:**
+
+*(Note: You'll need to have a `sample_question_paper_with_key.pdf` or similar file in the `data/` directory for this example. This file should contain the questions and their corresponding correct answers, as it will be used to generate the structured question paper.)*
+```bash
+python src/agent.py data/sample_student_sheet.pdf data/sample_question_paper_with_key.pdf --ollama-url http://localhost:11434
+```
+
+**Expected Output (Ollama Answer Extractor):**
+
+The script will print processing steps for both stages (Question Paper JSON generation and Answer Extraction) and then output a final JSON structure containing the extracted answers from the student's sheet. An example snippet of the final output:
+
+```json
+{
+    "data": [
+        {
+            "id": "1-e125a4de-fcce-4988-9a88-9b32d89ebca3",
+            "question_number": "Q1",
+            "answers": [
+                {
+                    "id": "2-e125a4de-fcce-4988-9a88-9b32d89ebca3",
+                    "student_answer_text": "in"
+                }
+            ]
+        }
+    ],
+    "exam": [
+        {
+            "school_name": "",
+            "name": "Avantilka"
+        }
+    ]
+}
+```
+
+### Running the Gemini Answer Grader
+
+This mode scores a student's answer sheet against an answer key using the Gemini API.
 
 **Command Syntax:**
 
@@ -73,12 +142,12 @@ python src/agent.py <student_sheet_path> <answer_key_path> <your_gemini_api_key>
 **Arguments:**
 
 *   `student_sheet_path`: The file path to the student's answer sheet.
-    *   Supported formats: `.pdf`, `.png`, `.jpg`, `.jpeg`.
+    *   Supported formats: `.pdf`, `.png`, `.jpg`, `.jpeg`, `.txt`.
 *   `answer_key_path`: The file path to the answer key.
     *   Supported formats: `.pdf`, `.png`, `.jpg`, `.jpeg`, `.txt`.
 *   `your_gemini_api_key`: Your personal Gemini API key.
 
-**Examples using sample files from the `data/` directory:**
+**Examples (Gemini Grader):**
 
 1.  **Using a PDF student sheet and a TXT answer key:**
     ```bash
@@ -92,7 +161,7 @@ python src/agent.py <student_sheet_path> <answer_key_path> <your_gemini_api_key>
 
 Replace `YOUR_GEMINI_API_KEY` with your actual Gemini API key.
 
-**Expected Output:**
+**Expected Output (Gemini Grader):**
 
 The script will print the processing steps to the console, followed by the final grading result:
 
@@ -104,7 +173,7 @@ Reading text from TXT file: data/sample_answer_key.txt
 Scoring answers...
 
 --- Results ---
-Score: XX% 
+Score: XX%
 Feedback:
 [Qualitative feedback from the Gemini model]
 ```
@@ -113,9 +182,11 @@ The score and feedback will vary based on the content of the files and the model
 ## File Structure
 
 *   `src/`: Contains the core Python modules for the application.
-    *   `agent.py`: The main command-line interface script.
+    *   `agent.py`: The main command-line interface script, routing to different functionalities based on arguments.
     *   `pdf_processing.py`: Handles text extraction from PDF files.
     *   `image_processing.py`: Handles text extraction from image files.
+    *   `ollama_client.py`: Handles communication with the Ollama API.
+    *   `answer_extractor.py`: Implements logic for extracting structured answers using Ollama.
     *   `scorer.py`: Interacts with the Gemini API to score answers.
 *   `data/`: Includes sample files for testing and demonstration.
     *   `sample_student_sheet.pdf`: A sample PDF answer sheet.
@@ -129,11 +200,24 @@ The score and feedback will vary based on the content of the files and the model
 ## Limitations
 
 *   **OCR Accuracy:** The accuracy of text extraction from images (and some PDFs) depends heavily on the input quality (e.g., clarity of text, font style, image resolution, layout complexity). Handwriting is generally not well supported by the current OCR setup.
-*   **Gemini Model Performance:** The quality of the scoring and feedback is dependent on the Gemini model's understanding of the provided text, the clarity of the student's answers, the comprehensiveness of the answer key, and the effectiveness of the internal prompt used.
-*   **Answer Key Format:** While text-based answer keys (`.txt`) are most reliable, PDF and image keys are subject to OCR accuracy. For best results, answer keys should have clear, machine-readable text.
+*   **LLM Performance (General):** The quality of results for both answer extraction (Ollama) and grading (Gemini) depends significantly on:
+    *   The capabilities of the specific LLM used (e.g., `gemma3:12b` for Ollama, Gemini Pro).
+    *   The clarity and quality of the OCR'd student script.
+    *   For the Ollama feature:
+        *   The clarity and quality of the OCR'd "question paper with answers (key)" file.
+        *   The LLM's ability to accurately convert this OCR text into the required structured JSON format.
+        *   The quality of the LLM-generated question paper JSON.
+    *   For the Gemini feature: The detail and correctness of the provided answer key.
+    *   The effectiveness of the prompts used internally for all LLM calls.
+*   **Ollama Setup:** The Ollama-based extraction requires a correctly configured and accessible Ollama instance. Performance can vary based on the model used and the hardware running Ollama.
+*   **Multi-Stage LLM Dependency (Ollama):** The success of the Ollama answer extraction is now dependent on two sequential LLM calls:
+    1.  Generation of the question paper JSON from the provided key file.
+    2.  Extraction of answers from the student script based on the generated JSON.
+    Errors or poor quality in the first stage will directly impact the second stage.
+*   **Answer Key Format (Gemini):** While text-based answer keys (`.txt`) are most reliable for the Gemini grader, PDF and image keys are subject to OCR accuracy. For best results, answer keys should have clear, machine-readable text.
 *   **No Graphical User Interface (GUI):** This is a command-line tool.
-*   **API Costs:** Use of the Google Gemini API may incur costs depending on your usage and Google's pricing model. Please refer to Google's API pricing documentation.
-*   **Error Handling:** While basic error handling is implemented (e.g., file not found, API issues), there might be edge cases not fully covered.
+*   **API Costs:** Use of the Google Gemini API may incur costs. Local Ollama usage depends on your own hardware.
+*   **Error Handling:** While basic error handling is implemented, there might be edge cases not fully covered.
 
 ## Running Tests
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ google-generativeai
 Pillow
 pytesseract
 PyMuPDF
+requests
 
 # For pytesseract to function, Tesseract-OCR must be installed on the system.
 # You may also need to configure the path to the Tesseract executable.

--- a/src/agent.py
+++ b/src/agent.py
@@ -6,25 +6,27 @@ import os
 try:
     from pdf_processing import extract_text_from_pdf
     from image_processing import extract_text_from_image
-    from scorer import score_answers
+    from answer_extractor import extract_answers_with_ollama
+    from question_paper_json_generator import generate_question_paper_json_from_text # Added
 except ImportError:
-    # Fallback for direct execution if modules are in the same directory
-    # and not installed as a package.
-    # This assumes src/ is the current working directory or in PYTHONPATH
+    # Fallback for direct execution
     try:
         from src.pdf_processing import extract_text_from_pdf
         from src.image_processing import extract_text_from_image
-        from src.scorer import score_answers
+        from src.answer_extractor import extract_answers_with_ollama
+        from src.question_paper_json_generator import generate_question_paper_json_from_text # Added
     except ImportError as e:
         print(f"Error importing modules: {e}. Ensure the 'src' directory is in your PYTHONPATH or run from the project root.")
         exit(1)
+
+import json
 
 
 def get_text_from_file(file_path: str) -> str | None:
     """
     Extracts text from a file based on its extension.
 
-    Supports PDF, common image formats (PNG, JPG, JPEG), and TXT files.
+    Supports PDF, common image formats (PNG, JPG, JPEG), TXT, and JSON files.
 
     Args:
         file_path: The path to the file.
@@ -45,62 +47,96 @@ def get_text_from_file(file_path: str) -> str | None:
     elif file_extension in ['.png', '.jpg', '.jpeg']:
         print(f"Extracting text from image: {file_path}")
         return extract_text_from_image(file_path)
-    elif file_extension == '.txt':
-        print(f"Reading text from TXT file: {file_path}")
+    elif file_extension == '.txt' or file_extension == '.json': # Added .json
+        print(f"Reading text from {file_extension.upper()} file: {file_path}")
         try:
             with open(file_path, 'r', encoding='utf-8') as f:
                 return f.read()
         except Exception as e:
-            print(f"Error reading text file '{file_path}': {e}")
+            print(f"Error reading text/json file '{file_path}': {e}")
             return None
     else:
         print(f"Error: Unsupported file type '{file_extension}' for file '{file_path}'.")
-        print("Supported types: .pdf, .png, .jpg, .jpeg, .txt")
+        print("Supported types: .pdf, .png, .jpg, .jpeg, .txt, .json")
         return None
 
 
 def main():
     """
-    Main function to parse arguments, process files, and score answers.
+    Main function to parse arguments, process files, and orchestrate the two-stage answer extraction using Ollama.
     """
-    parser = argparse.ArgumentParser(description="Grade student answer sheets using Gemini API.")
-    parser.add_argument("student_sheet_path", help="Path to the student's answer sheet (PDF, PNG, JPG, JPEG, or TXT).")
-    parser.add_argument("answer_key_path", help="Path to the answer key (PDF, PNG, JPG, JPEG, or TXT).")
-    parser.add_argument("api_key", help="Your Gemini API key.")
+    parser = argparse.ArgumentParser(description="Extracts answers from student sheets using a two-stage Ollama process.")
+    parser.add_argument("student_sheet_path", help="Path to the student's answer sheet (PDF, PNG, JPG, JPEG, or TXT for OCR).")
+    parser.add_argument("question_paper_path", help="Path to the question paper with answers (key) file (PDF, image, or TXT for OCR).")
+    parser.add_argument("--ollama-url", required=True, help="Base URL for the Ollama API (e.g., http://localhost:11434)")
+    parser.add_argument("--ollama-model", default="gemma3:12b", help="Name of the Ollama model to use (default: gemma3:12b)")
 
     args = parser.parse_args()
 
-    print("Processing student answer sheet...")
+    # Step A: Process Student Answer Sheet
+    print("Step A: Processing student answer sheet...")
     student_text = get_text_from_file(args.student_sheet_path)
-    if student_text is None or student_text.strip() == "":
-        print(f"Could not extract text from student sheet '{args.student_sheet_path}' or sheet is empty. Exiting.")
-        return # Exit if student text extraction failed or is empty
+    if not student_text: # Handles None or empty string after strip more generally
+        if student_text is None: # Specifically if file not found or major error
+             print(f"Could not extract text from student sheet '{args.student_sheet_path}'. Exiting.")
+             return
+        else: # If file was read but OCR yielded empty text
+            print(f"Warning: Student sheet '{args.student_sheet_path}' yielded empty text after OCR/reading. Processing will continue with empty student answers.")
+            # student_text will be "" which is acceptable for extract_answers_with_ollama
 
-    print("\nProcessing answer key...")
-    answer_key_text = get_text_from_file(args.answer_key_path)
-    if answer_key_text is None or answer_key_text.strip() == "":
-        print(f"Could not extract text from answer key '{args.answer_key_path}' or key is empty. Exiting.")
-        return # Exit if answer key extraction failed or is empty
+    # Step B: Process "Question Paper with Answers (Key)" File
+    print("\nStep B: Processing question paper with answers (key) file...")
+    question_paper_ocr_text = get_text_from_file(args.question_paper_path)
+    if not question_paper_ocr_text: # Handles None or empty string
+        print(f"Could not extract text from question paper file '{args.question_paper_path}' or file is empty. Exiting.")
+        return
 
-    print("\nScoring answers...")
-    # Ensure that empty strings (after stripping whitespace) are handled by score_answers or here.
-    # The current implementation of get_text_from_file returns "" on some errors, not None.
-    # Adding explicit checks for empty strings after extraction.
+    print("\nGenerating structured Question Paper JSON from its OCR text...")
+    generated_qp_dict = generate_question_paper_json_from_text(
+        ocr_text_of_question_paper_with_key=question_paper_ocr_text,
+        ollama_base_url=args.ollama_url,
+        ollama_model_name=args.ollama_model
+    )
 
-    scoring_result = score_answers(student_text, answer_key_text, args.api_key)
+    if "error" in generated_qp_dict:
+        print(f"Failed to generate Question Paper JSON: {generated_qp_dict.get('error')}")
+        if "details" in generated_qp_dict:
+            print(f"Details: {generated_qp_dict.get('details')}")
+        if "raw_model_content" in generated_qp_dict:
+            print(f"Raw Model Content for QP JSON generation (if available):\n{generated_qp_dict.get('raw_model_content', 'N/A')}")
+        return
 
-    print("\n--- Results ---")
-    if "error" in scoring_result:
-        print(f"Scoring failed: {scoring_result['error']}")
-        if "details" in scoring_result:
-            print(f"Details: {scoring_result['details']}")
-        if "raw_response" in scoring_result:
-            print(f"Raw Model Response (if available):\n{scoring_result['raw_response']}")
+    # Convert the generated QP dict to a JSON string for the next step
+    try:
+        question_paper_json_string = json.dumps(generated_qp_dict)
+        print("Successfully generated and serialized Question Paper JSON.")
+    except TypeError as e:
+        print(f"Error serializing generated Question Paper JSON: {e}. Exiting.")
+        return
+
+
+    # Step C: Extract Answers using Generated Question Paper JSON
+    print("\nStep C: Extracting answers from student script using generated Question Paper JSON...")
+    final_extraction_result = extract_answers_with_ollama(
+        question_paper_json=question_paper_json_string,
+        answer_script_ocr=student_text if student_text is not None else "", # Ensure student_text is not None
+        ollama_base_url=args.ollama_url,
+        ollama_model_name=args.ollama_model
+    )
+
+    # Step D: Output Handling
+    print("\n--- Final Extracted Answers ---")
+    if "error" in final_extraction_result:
+        print(f"Answer extraction failed: {final_extraction_result.get('error')}")
+        if "details" in final_extraction_result:
+            print(f"Details: {final_extraction_result.get('details')}")
+        # Check for different raw content keys from the two possible error sources
+        if "raw_model_content" in final_extraction_result: 
+            print(f"Raw Model Content for Answer Extraction (if available):\n{final_extraction_result.get('raw_model_content', 'N/A')}")
+        elif "raw_response" in final_extraction_result: # from ollama_client if it errored before model response
+             print(f"Raw Ollama Client Response for Answer Extraction (if available):\n{final_extraction_result.get('raw_response', 'N/A')}")
     else:
-        score = scoring_result.get("score", "N/A")
-        feedback = scoring_result.get("feedback", "No feedback provided.")
-        print(f"Score: {score}%" if isinstance(score, (int, float)) else f"Score: {score}")
-        print(f"Feedback:\n{feedback}")
+        print(json.dumps(final_extraction_result, indent=4))
 
 
 if __name__ == '__main__':

--- a/src/answer_extractor.py
+++ b/src/answer_extractor.py
@@ -1,0 +1,260 @@
+import json
+from src.ollama_client import send_request_to_ollama
+
+def extract_answers_with_ollama(question_paper_json: str, answer_script_ocr: str, ollama_base_url: str, ollama_model_name: str = "gemma3:12b") -> dict:
+    """
+    Extracts answers from an answer script OCR using Ollama.
+
+    Args:
+        question_paper_json: JSON string of the question paper.
+        answer_script_ocr: OCR text of the student's answer script.
+        ollama_base_url: The base URL of the Ollama API.
+        ollama_model_name: The name of the Ollama model to use.
+
+    Returns:
+        A dictionary containing the raw response from the Ollama API.
+    """
+
+    prompt = f"""
+You are an expert AI assistant tasked with extracting structured information from a student's answer script based on a provided question paper. Your goal is to identify which questions were attempted and what the corresponding answers are.
+
+**Question Paper (For Reference Only, Do Not Include Answers):**
+---JSON START---
+{question_paper_json}
+---JSON END---
+
+**Answer Script OCR:**
+---OCR START---
+{answer_script_ocr}
+---OCR END---
+
+**Important:**
+*   **Focus on Extraction, Not Evaluation:** Your primary task is to extract the student's answers as accurately as possible. Do not try to grade the answers or provide feedback on their correctness.
+*   **Handle Missing Answers:** If a student did not attempt a question, clearly indicate this (e.g., "Not Attempted").
+*   **Interpret OCR Imperfections:** OCR output can be messy. Use the context from the question paper to make reasonable interpretations of the student's intent.
+*   **Maintain Order:** Present the extracted answers in the same order as the questions appear in the question paper.
+*   **Output Format:** The final output should be a JSON object where keys are question numbers (as strings, e.g., "1a", "2bii") and values are the extracted answers (as strings).
+
+**Detailed Steps:**
+1.  **Parse Question Paper:** Understand the structure of the question paper (sections, question numbers, sub-parts).
+2.  **Scan Answer Script:** Read through the OCR text of the answer script.
+3.  **Map Answers to Questions:** For each question in the question paper, locate the corresponding answer in the answer script.
+    *   Students might explicitly number their answers (e.g., "Answer to Q1a:", "1) a)").
+    *   They might answer questions out of order.
+    *   They might not attempt all questions.
+4.  **Extract Answer Text:** Once an answer is located, extract the full text of that answer.
+    *   Be careful to capture multi-line answers.
+    *   If an answer involves diagrams, code snippets, or mathematical equations that are poorly represented in OCR, make a note (e.g., "[Diagram present, OCR may be incomplete]").
+5.  **Handle Ambiguity:** If it's genuinely unclear which question an answer pertains to, or if an answer is completely illegible, note this.
+
+**Metadata Extraction (If Possible):**
+*   Look for any student identifiers (name, ID) or exam details at the beginning of the answer script. Extract these if present, perhaps under a special key like `"_metadata"`.
+
+**Organization:**
+*   Structure your primary output around the question numbers from the question paper.
+*   For questions with sub-parts (e.g., 1a, 1b), use nested structures or clear identifiers.
+
+**Challenges and Notes:**
+*   **Handwriting Quality:** OCR of handwritten text can be poor. Prioritize clear matches.
+*   **Answer Numbering:** Students might use inconsistent numbering. The question paper is your ground truth for structure.
+*   **Implicit Answers:** Sometimes answers are embedded within a larger narrative. Extract the relevant portion.
+*   **Partial Answers:** If a student only partially answers a question, extract what's there.
+
+**Expected Output Structure (Example):**
+---JSON EXAMPLE START---
+{{
+  "1a": "The capital of France is Paris.",
+  "1b": "The main components of a CPU are the ALU and Control Unit.",
+  "2": "Not Attempted",
+  "3i": "[Diagram present, OCR may be incomplete] The process involves...",
+  "_metadata": {{
+    "student_name": "Jane Doe",
+    "student_id": "12345"
+  }}
+}}
+---JSON EXAMPLE END---
+
+Based on the provided Question Paper and Answer Script OCR, please extract the answers and return them in the specified JSON format.
+"""
+
+    # 2. Call Ollama API
+    ollama_response_dict = send_request_to_ollama(
+        prompt=prompt,
+        base_url=ollama_base_url,
+        model_name=ollama_model_name
+    )
+
+    # 3. Check for errors from the client itself
+    if 'error' in ollama_response_dict:
+        # ollama_client already returns a dict with an 'error' key
+        return ollama_response_dict
+
+    # 4. Extract the model's actual response text
+    # Ollama's /api/generate endpoint (when stream=False) returns a JSON where
+    # the model's output is in the 'response' field.
+    model_content_text = ollama_response_dict.get('response')
+    
+    if model_content_text is None: # Check for None specifically, as empty string might be valid in some edge cases
+        return {"error": "No 'response' field in Ollama output", "raw_response": ollama_response_dict}
+    
+    if not isinstance(model_content_text, str):
+        return {"error": "'response' field is not a string", "raw_response": ollama_response_dict}
+
+    # 5. Parse the JSON content from the model's response
+    try:
+        # The model's response string is expected to be a JSON representing the structured data
+        parsed_output = json.loads(model_content_text)
+        
+        # Basic validation for top-level keys and type
+        if not isinstance(parsed_output, dict):
+            return {
+                "error": "Model output, when parsed, is not a dictionary.",
+                "raw_model_content": model_content_text,
+                "parsed_type": type(parsed_output).__name__
+            }
+
+        # Schema adherence for "data" and "exam" keys - this is a simplified check.
+        # The prompt asks for a specific structure like {"1a": "answer", "_metadata": {...}}
+        # For now, the subtask asks for "data" and "exam" at the top level.
+        # Let's adjust the prompt's "Expected Output Structure" example if this is a mismatch.
+        # For now, I will stick to the "data" and "exam" keys as per the subtask description for validation.
+        # If the prompt's example output (e.g. {"1a": ..., "_metadata": ...}) is the actual expected structure
+        # then this validation needs to be changed or the prompt's example needs to be wrapped.
+        # Assuming the subtask's example structure is the target for this function's return.
+        #
+        # Re-reading the prompt: "Expected Output Structure (Example):" shows direct question numbers as keys.
+        # The subtask says: "ensure the top-level keys ("data", "exam") are present."
+        # This implies the actual desired output from this *function* might be:
+        # { "data": { "1a": "Paris", ... }, "exam": { ... } }
+        # However, the prompt to the LLM shows: { "1a": "Paris", ... }
+        # This is a point of ambiguity. I will assume the LLM produces the flat structure (as in its prompt)
+        # and this Python function is NOT expected to wrap it further with "data" and "exam".
+        # The validation "data" and "exam" must then refer to keys *within* the LLM's output,
+        # which is not what the LLM prompt asks for.
+        #
+        # Clarification: The issue description for *this current subtask* says:
+        # "ensure the top-level keys ("data", "exam") are present." and refers to an "Output Structure"
+        # from "the issue". It's possible "the issue" refers to the overall project issue, not just the LLM prompt.
+        #
+        # Given the example in *this subtask's description*:
+        # # Basic validation for top-level keys
+        # if not isinstance(parsed_output, dict) or "data" not in parsed_output or "exam" not in parsed_output:
+        #
+        # I will implement this validation. This means the LLM *is* expected to return a JSON
+        # with "data" and "exam" as top-level keys. The current LLM prompt needs to be updated
+        # in a future step to reflect this. For now, I will implement the validation as requested.
+
+        required_keys = ["data", "exam"] # As per subtask description
+        missing_keys = [key for key in required_keys if key not in parsed_output]
+        
+        if missing_keys:
+            return {
+                "error": f"Model output JSON is missing required top-level keys: {', '.join(missing_keys)}",
+                "raw_model_content": model_content_text,
+                "parsed_json_keys": list(parsed_output.keys())
+            }
+            
+        return parsed_output # This is the successfully parsed Python dictionary
+
+    except json.JSONDecodeError as e:
+        return {
+            "error": "Failed to parse JSON from model output",
+            "details": str(e),
+            "raw_model_content": model_content_text
+        }
+    except Exception as e: # Catch any other unexpected errors during parsing/validation
+        return {
+            "error": "An unexpected error occurred while processing model output",
+            "details": str(e),
+            "raw_model_content": model_content_text # Include raw content for debugging
+        }
+
+if __name__ == '__main__':
+    # Example Usage (Illustrative - requires a running Ollama instance and sample data)
+    # Note: The sample_question_paper_json and sample_answer_script_ocr are simplified.
+    # The LLM prompt expects a more detailed JSON for question_paper_json.
+    # The ollama_model_name is also illustrative.
+    sample_question_paper_json = json.dumps({
+        "1": {
+            "question": "What is the capital of France?",
+            "marks": 2
+        },
+        "2a": {
+            "question": "Explain the concept of photosynthesis.",
+            "marks": 5
+        },
+        "2b": {
+            "question": "What are the reactants in photosynthesis?",
+            "marks": 3
+        }
+    })
+
+    sample_answer_script_ocr = """
+    Student Name: John Doe
+    Student ID: S12345
+
+    Answer 1:
+    Paris is the capital of France.
+
+    Answer 2a:
+    Photosynthesis is the process by which green plants use sunlight, water, and carbon dioxide to create their own food and release oxygen.
+
+    Answer 2b:
+    The reactants are sunlight, water, and carbon dioxide.
+    """
+
+    # This ollama_model_name is defined in the function signature as a default.
+    # To make it available here, it should be defined outside or passed explicitly.
+    # For simplicity, let's use the default directly in the print statement or define it.
+    current_model_for_testing = "gemma3:12b" # or extract_answers_with_ollama.__defaults__[0] if it's the first default
+
+    ollama_api_base_url = "http://localhost:11434" # Replace if your Ollama runs elsewhere
+
+    print(f"Attempting to extract answers using Ollama model: {current_model_for_testing}")
+    
+    # This example call will likely fail if Ollama isn't running or if the model
+    # doesn't produce the exact JSON structure with "data" and "exam" keys.
+    # The purpose of this __main__ block is illustrative.
+    processed_output = extract_answers_with_ollama(
+        sample_question_paper_json,
+        sample_answer_script_ocr,
+        ollama_api_base_url,
+        ollama_model_name=current_model_for_testing
+    )
+
+    print("\n--- Example Call Results ---")
+    if "error" in processed_output:
+        print(f"Error processing Ollama response: {processed_output['error']}")
+        if "details" in processed_output:
+            print(f"Details: {processed_output['details']}")
+        if "raw_model_content" in processed_output:
+            print(f"Raw model content was: {processed_output['raw_model_content']}")
+        if "raw_response" in processed_output:
+            print(f"Raw Ollama client response was: {processed_output['raw_response']}")
+    else:
+        # If successful, processed_output is the Python dictionary from the model's JSON
+        print("Successfully processed Ollama response.")
+        print("Extracted data (Python dict):")
+        print(json.dumps(processed_output, indent=2))
+        # Example: Accessing data (assuming "data" and "exam" keys exist as per validation)
+        # print("\nAccessing specific parts (example):")
+        # print(f"Exam details: {processed_output.get('exam')}")
+        # print(f"Answer data: {processed_output.get('data')}")
+
+
+    # Example with a non-existent model to test error handling from ollama_client via send_request_to_ollama
+    print("\n--- Testing Non-Existent Model ---")
+    error_output = extract_answers_with_ollama(
+        sample_question_paper_json,
+        sample_answer_script_ocr,
+        ollama_api_base_url,
+        ollama_model_name="non_existent_model_gemma"
+    )
+    if "error" in error_output:
+        print(f"Successfully caught error for non-existent model: {error_output['error']}")
+        if "details" in error_output: # If the error came from ollama_client
+            print(f"Details: {error_output['details']}")
+    else:
+        print("Error for non-existent model was not caught as expected.")
+        print(error_output)
+```

--- a/src/ollama_client.py
+++ b/src/ollama_client.py
@@ -1,0 +1,55 @@
+import requests
+import json
+
+def send_request_to_ollama(prompt: str, base_url: str, model_name: str = "gemma3:12b", options: dict = None) -> dict:
+    """
+    Sends a request to the Ollama API and returns the response.
+
+    Args:
+        prompt: The prompt to send to the model.
+        base_url: The base URL of the Ollama API.
+        model_name: The name of the model to use.
+        options: A dictionary of options for the Ollama API.
+
+    Returns:
+        A dictionary containing the response from the Ollama API.
+    """
+    api_url = f"{base_url}/api/generate"
+    headers = {"Content-Type": "application/json"}
+    payload = {
+        "model": model_name,
+        "prompt": prompt,
+        "stream": False,
+    }
+    if options:
+        payload["options"] = options
+
+    try:
+        response = requests.post(api_url, headers=headers, data=json.dumps(payload))
+        response.raise_for_status()  # Raise an exception for bad status codes (4xx or 5xx)
+        return response.json()
+    except requests.exceptions.RequestException as e:
+        return {"error": f"Request failed: {e}"}
+    except json.JSONDecodeError:
+        return {"error": "Failed to decode JSON response"}
+
+if __name__ == '__main__':
+    # Example usage (optional, for testing)
+    # Replace with your actual Ollama API base URL if different
+    ollama_base_url = "http://localhost:11434"
+    
+    # Example prompt
+    example_prompt = "What is the capital of France?"
+    
+    # Example options (optional)
+    example_options = {"temperature": 0.7}
+    
+    print(f"Sending request to Ollama with prompt: '{example_prompt}'")
+    response_data = send_request_to_ollama(example_prompt, ollama_base_url, options=example_options)
+    
+    if "error" in response_data:
+        print(f"Error: {response_data['error']}")
+    elif "response" in response_data:
+        print(f"Ollama's response: {response_data['response']}")
+    else:
+        print(f"Full response data: {response_data}")

--- a/src/question_paper_json_generator.py
+++ b/src/question_paper_json_generator.py
@@ -1,0 +1,202 @@
+import json
+from src.ollama_client import send_request_to_ollama
+import re # For basic JSON cleanup
+
+def generate_question_paper_json_from_text(ocr_text_of_question_paper_with_key: str, ollama_base_url: str, ollama_model_name: str = "gemma3:12b") -> dict:
+    """
+    Generates a structured JSON for a question paper from its OCR text (including answers) using Ollama.
+
+    Args:
+        ocr_text_of_question_paper_with_key: Raw OCR text of the question paper, including answers.
+        ollama_base_url: The base URL of the Ollama API.
+        ollama_model_name: The name of the Ollama model to use.
+
+    Returns:
+        A Python dictionary representing the structured question paper, or an error dictionary.
+    """
+
+    prompt_template = """
+You are an expert AI assistant tasked with converting a raw OCR text dump of a question paper (which includes answers) into a structured JSON format. This JSON will be used by other AI systems to understand the questions, their structure, associated marks, and the correct answers.
+
+**Input:**
+You will receive a single block of text which is the OCR output of a question paper that also contains the answers to the questions.
+
+**Output Structure:**
+The output MUST be a single JSON object. This JSON object must have two top-level keys:
+1.  `"exam"`: An array containing a single object with metadata about the exam.
+2.  `"data"`: An array of objects, where each object represents a main question.
+
+**Field Definitions:**
+
+**1. `exam` (Array, contains one object):**
+   *   `id`: (String) A unique identifier for this exam. UUID format preferred.
+   *   `exam_name`: (String) The name of the exam (e.g., "Midterm Exam", "Class Test"). Extract if available, otherwise use "N/A".
+   *   `subject`: (String) Subject of the exam (e.g., "Mathematics", "Physics"). Extract if available, otherwise use "N/A".
+   *   `standard`: (String) Class or grade level (e.g., "10th Grade", "Class V"). Extract if available, otherwise use "N/A".
+   *   `total_marks`: (Float/Integer) Total marks for the exam. Extract if available, otherwise use 0.0.
+   *   `duration`: (String) Duration of the exam (e.g., "2 hours", "90 minutes"). Extract if available, otherwise use "N/A".
+   *   `school_name`: (String) Name of the school or institution. Extract if available, otherwise use "N/A".
+   *   `exam_instructions`: (String) General instructions for the exam. Extract if available, otherwise use "N/A".
+   *   `exam_date`: (String) Date of the exam. Extract if available, otherwise use "N/A".
+   *   `class_section`: (String) Section of the class, if applicable. Extract if available, otherwise use "N/A".
+   *   `exam_set`: (String) Exam set identifier (e.g., "Set A", "Set 1"). Extract if available, otherwise use "N/A".
+   *   `total_questions`: (Integer) The total number of main questions in the paper. Calculate this by counting the top-level items in the "data" array.
+
+**2. `data` (Array of question objects):**
+   Each object in this array represents a main question (e.g., Q1, Q2a, Question 3).
+   *   `id`: (String) A unique identifier for this main question. UUID format preferred.
+   *   `question_number`: (String) The designation of the question (e.g., "1", "2a", "Section A Q1"). Try to capture this as accurately as it appears.
+   *   `question_section`: (String) The section of the paper this question belongs to (e.g., "Section A", "Part 1"). If not specified, use "N/A".
+   *   `supporting_text`: (String) Any introductory text or passage that applies to this main question but precedes its sub-questions (if any). If none, use an empty string "".
+   *   `marks`: (Float/Integer) Marks allocated to this main question (sum of its sub-questions if applicable, or marks for the question itself if no sub-questions). If not specified, use 0.0.
+   *   `contains_OR_questions`: (Boolean) Set to `true` if this main question offers an internal choice (e.g., "Answer Q3a OR Q3b"). Otherwise, `false`.
+   *   `questions`: (Array of sub-question objects) Contains the actual question text(s). If a main question has no sub-parts (e.g. "Q1. What is X?"), this array will still contain one object for that question.
+      *   `id`: (String) A unique identifier for this specific question/sub-question. UUID format preferred.
+      *   `subquestion_number`: (String) The sub-question number (e.g., "a", "i", "part 1"). If the main question has no sub-numbering, use an empty string "".
+      *   `question_text`: (String) The full text of the question.
+      *   `question_instruction`: (String) Any specific instruction for this question (e.g., "Fill in the blank", "Choose the correct option", "Max 100 words"). If none, use an empty string "".
+      *   `question_diagram_description`: (String) A brief description if a diagram is associated with/part of the question text. E.g., "Diagram shows a circuit." If none, use an empty string "".
+      *   `answer_text`: (String) The **correct answer** to this question/sub-question. This is critical. Extract this from the provided text. If the answer is not found or is ambiguous, use "Answer not found".
+
+**Important Considerations:**
+*   **Uniqueness of IDs:** Ensure all `id` fields (for exam, main questions, and sub-questions) are unique strings. UUID format is preferred but any unique string is acceptable.
+*   **Accuracy:** Extract all information as accurately as possible from the provided text.
+*   **Completeness:** Try to populate all fields. If information for a field is not available in the text, use the specified default values (e.g., "N/A", 0.0, "", false).
+*   **Hierarchical Structure:** Pay close attention to the hierarchy of questions and sub-questions. A main question in the `data` array can have multiple sub-questions in its `questions` array.
+*   **"OR" Questions:** If a question offers a choice (e.g., "Q1. Do X OR Do Y"), the `contains_OR_questions` field for the parent question in `data` should be `true`. Both options (X and Y) should then be listed as separate sub-questions within the `questions` array, each with its own ID, text, and answer.
+*   **Marks Allocation:**
+    *   If a main question has sub-questions, its `marks` field should ideally be the sum of the marks of its sub-questions. If only total marks for the main question are given, try to distribute them or note it. If marks are only specified per sub-question, sum them up for the parent.
+    *   If marks are not specified anywhere, use 0.0.
+*   **Answer Extraction:** This is a key part. The input text contains answers. Ensure the `answer_text` field for each question/sub-question is correctly populated with its corresponding answer from the text.
+*   **JSON Validity:** The final output MUST be a valid JSON. Do not include any text or explanations outside the main JSON object. Ensure all strings are properly escaped.
+
+**Input OCR Text:**
+---OCR TEXT START---
+{ocr_text_of_question_paper_with_key}
+---OCR TEXT END---
+
+**Generate the structured JSON output based on the above instructions and the provided OCR text.**
+"""
+
+    full_prompt = prompt_template.format(ocr_text_of_question_paper_with_key=ocr_text_of_question_paper_with_key)
+
+    ollama_response = send_request_to_ollama(
+        prompt=full_prompt,
+        base_url=ollama_base_url,
+        model_name=ollama_model_name
+    )
+
+    if 'error' in ollama_response:
+        return {
+            "error": "Ollama API call failed for JSON generation",
+            "details": ollama_response.get('error')
+        }
+
+    model_content_text = ollama_response.get('response')
+    if not model_content_text or not model_content_text.strip():
+        return {
+            "error": "No content in Ollama response for JSON generation",
+            "raw_response": ollama_response
+        }
+
+    # Basic cleanup: try to find the JSON block.
+    # This looks for the first '{' and the last '}'
+    try:
+        json_start_index = model_content_text.index('{')
+        json_end_index = model_content_text.rindex('}') + 1
+        potential_json_str = model_content_text[json_start_index:json_end_index]
+    except ValueError:
+        potential_json_str = model_content_text # Fallback to using the whole string if '{' or '}' not found
+
+    try:
+        parsed_output = json.loads(potential_json_str)
+    except json.JSONDecodeError as e:
+        # Try another cleanup: remove common markdown code block delimiters if present
+        cleaned_text = re.sub(r'^```json\s*|\s*```$', '', potential_json_str.strip(), flags=re.MULTILINE)
+        try:
+            parsed_output = json.loads(cleaned_text)
+        except json.JSONDecodeError as e2:
+            return {
+                "error": "Failed to parse JSON from model output after cleanup",
+                "details": str(e2),
+                "original_json_error": str(e),
+                "raw_model_content": model_content_text
+            }
+
+
+    if not isinstance(parsed_output, dict):
+        return {
+            "error": "Parsed output is not a dictionary.",
+            "raw_model_content": model_content_text,
+            "parsed_type": type(parsed_output).__name__
+        }
+
+    required_keys = ["data", "exam"]
+    missing_keys = [key for key in required_keys if key not in parsed_output]
+    if missing_keys:
+        return {
+            "error": f"Parsed JSON is missing required top-level keys: {', '.join(missing_keys)}",
+            "raw_model_content": model_content_text,
+            "parsed_json_keys": list(parsed_output.keys())
+        }
+
+    return parsed_output
+
+
+if __name__ == '__main__':
+    sample_ocr_text = """
+    Midterm Exam - Physics - Class X
+    Total Marks: 100 Duration: 3 hours
+    School: Future Scholars Academy Date: 2024-08-15
+    Instructions: Attempt all questions.
+
+    Section A
+    Q1. What is the speed of light? (5 marks)
+    Answer: The speed of light is 3 x 10^8 m/s.
+
+    Q2. Define force. (5 marks)
+    Answer: Force is a push or pull upon an object resulting from the object's interaction with another object.
+
+    Section B
+    Q3. Explain Newton's first law of motion. (10 marks)
+    Answer: Newton's first law states that an object will remain at rest or in uniform motion in a straight line unless acted upon by an external force.
+    
+    Q3a. Give an example of inertia. (5 marks)
+    Answer: A person standing in a bus tends to fall backward when the bus suddenly starts.
+    (This should be under Q3's questions array)
+    """
+
+    # This URL is for local testing and won't work in the tool's environment
+    # without a running Ollama instance accessible to it.
+    sample_ollama_url = "http://localhost:11434" 
+    sample_model = "gemma3:12b" # Example model
+
+    print(f"--- Attempting to generate Question Paper JSON (Example) ---")
+    print(f"Using Ollama URL: {sample_ollama_url} (Note: This will likely fail if Ollama is not running or accessible)")
+
+    # Simulate a call, expecting it to fail gracefully if Ollama isn't available
+    # or return a structured error from the function itself.
+    generated_json = generate_question_paper_json_from_text(
+        ocr_text_of_question_paper_with_key=sample_ocr_text,
+        ollama_base_url=sample_ollama_url,
+        ollama_model_name=sample_model
+    )
+
+    print("\n--- Result from generate_question_paper_json_from_text ---")
+    if "error" in generated_json:
+        print(f"Error: {generated_json['error']}")
+        if "details" in generated_json:
+            print(f"Details: {generated_json['details']}")
+        if "raw_model_content" in generated_json:
+            print(f"Raw Model Content (if available for debugging): {generated_json['raw_model_content'][:500]}...") # Print first 500 chars
+    else:
+        print("Successfully generated JSON (or received a structured response from LLM to be parsed as JSON):")
+        print(json.dumps(generated_json, indent=4))
+
+    print("\n--- Note for testing ---")
+    print("The above example call in `if __name__ == '__main__':` is illustrative.")
+    print("For actual generation, ensure your Ollama instance is running and accessible at the specified URL,")
+    print("and the model is available. The function is designed to call out to this service.")
+    print("If the Ollama service is not reachable, an error related to the HTTP request will be shown.")
+
+```


### PR DESCRIPTION
…ere's a summary of the changes:

- I added a new Python script, `question_paper_json_generator.py`. This script takes the OCR text from a question paper (including answers) and uses Ollama to convert it into a structured JSON format.
- I updated `agent.py` to manage the new workflow. Here's how it works now:
    1. First, I'll perform OCR on the 'question paper with answers (key)' file you provide.
    2. Then, I'll use the new generator script to create a structured JSON representation of the question paper.
    3. Finally, I'll use this generated JSON with the existing Ollama answer extractor.
- I also updated the `README.md` file. It now reflects that the question paper can be a PDF, image, or TXT file (instead of requiring a pre-formatted JSON). It also details the new two-stage LLM process.